### PR TITLE
Update to tree-sitter 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,10 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.22.6"
+tree-sitter-language = "0.1.0"
+
+[dev-dependencies]
+tree-sitter = "0.23.0"
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tree-sitter-proto"
 description = "proto grammar for the tree-sitter parsing library"
-version = "0.0.1"
+version = "0.1.0"
 keywords = ["incremental", "parsing", "proto"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-javascript"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := 0.0.1
+VERSION := 0.1.0
 
 LANGUAGE_NAME := tree-sitter-proto
 

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifeq ($(shell echo $(PARSER_URL) | grep '^[a-z][-+.0-9a-z]*://'),)
 endif
 endif
 
-TS ?= npx tree-sitter-cli
+TS ?= tree-sitter
 
 # ABI versioning
 SONAME_MAJOR := $(word 1,$(subst ., ,$(VERSION)))

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ifeq ($(shell echo $(PARSER_URL) | grep '^[a-z][-+.0-9a-z]*://'),)
 endif
 endif
 
-TS ?= tree-sitter
+TS ?= npx tree-sitter-cli
 
 # ABI versioning
 SONAME_MAJOR := $(word 1,$(subst ., ,$(VERSION)))

--- a/bindings/go/binding_test.go
+++ b/bindings/go/binding_test.go
@@ -3,8 +3,8 @@ package tree_sitter_proto_test
 import (
 	"testing"
 
-	tree_sitter "github.com/smacker/go-tree-sitter"
-	"github.com/tree-sitter/tree-sitter-proto"
+	tree_sitter "github.com/tree-sitter/go-tree-sitter"
+	tree_sitter_proto "github.com/tree-sitter/tree-sitter-proto/bindings/go"
 )
 
 func TestCanLoadGrammar(t *testing.T) {

--- a/bindings/go/go.mod
+++ b/bindings/go/go.mod
@@ -1,5 +1,0 @@
-module github.com/tree-sitter/tree-sitter-proto
-
-go 1.22
-
-require github.com/smacker/go-tree-sitter v0.0.0-20230720070738-0d0a9f78d8f8

--- a/bindings/node/binding_test.js
+++ b/bindings/node/binding_test.js
@@ -1,0 +1,9 @@
+/// <reference types="node" />
+
+const assert = require("node:assert");
+const { test } = require("node:test");
+
+test("can load grammar", () => {
+  const parser = new (require("tree-sitter"))();
+  assert.doesNotThrow(() => parser.setLanguage(require(".")));
+});

--- a/bindings/python/tests/test_binding.py
+++ b/bindings/python/tests/test_binding.py
@@ -1,0 +1,11 @@
+from unittest import TestCase
+
+import tree_sitter, tree_sitter_proto
+
+
+class TestLanguage(TestCase):
+    def test_can_load_grammar(self):
+        try:
+            tree_sitter.Language(tree_sitter_proto.language())
+        except Exception:
+            self.fail("Error loading Proto grammar")

--- a/bindings/python/tree_sitter_proto/binding.c
+++ b/bindings/python/tree_sitter_proto/binding.c
@@ -4,8 +4,8 @@ typedef struct TSLanguage TSLanguage;
 
 TSLanguage *tree_sitter_proto(void);
 
-static PyObject* _binding_language(PyObject *self, PyObject *args) {
-    return PyLong_FromVoidPtr(tree_sitter_proto());
+static PyObject* _binding_language(PyObject *Py_UNUSED(self), PyObject *Py_UNUSED(args)) {
+    return PyCapsule_New(tree_sitter_proto(), "tree_sitter.Language", NULL);
 }
 
 static PyMethodDef methods[] = {

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -13,31 +13,6 @@ fn main() {
     let parser_path = src_dir.join("parser.c");
     c_config.file(&parser_path);
 
-    // If your language uses an external scanner written in C,
-    // then include this block of code:
-
-    /*
-    let scanner_path = src_dir.join("scanner.c");
-    c_config.file(&scanner_path);
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
-
     c_config.compile("parser");
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
-
-    // If your language uses an external scanner written in C++,
-    // then include this block of code:
-
-    /*
-    let mut cpp_config = cc::Build::new();
-    cpp_config.cpp(true);
-    cpp_config.include(&src_dir);
-    cpp_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable");
-    let scanner_path = src_dir.join("scanner.cc");
-    cpp_config.file(&scanner_path);
-    cpp_config.compile("scanner");
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    */
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,12 +1,16 @@
-//! This crate provides proto language support for the [tree-sitter][] parsing library.
+//! This crate provides Proto language support for the [tree-sitter][] parsing library.
 //!
 //! Typically, you will use the [language][language func] function to add this language to a
 //! tree-sitter [Parser][], and then use the parser to parse some code:
 //!
 //! ```
-//! let code = "";
+//! let code = r#"
+//! "#;
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_proto::language()).expect("Error loading proto grammar");
+//! let language = tree_sitter_proto::LANGUAGE;
+//! parser
+//!     .set_language(&language.into())
+//!     .expect("Error loading Proto parser");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!
@@ -15,30 +19,26 @@
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_proto() -> Language;
+    fn tree_sitter_proto() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
-///
-/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_proto() }
-}
+/// The tree-sitter [`LanguageFn`] for this grammar.
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_proto) };
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
-pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+pub const NODE_TYPES: &str = include_str!("../../src/node-types.json");
 
-// Uncomment these to include any queries that this grammar contains
+// NOTE: uncomment these to include any queries that this grammar contains:
 
-// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
-// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
-// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
-// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+// pub const HIGHLIGHTS_QUERY: &str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &str = include_str!("../../queries/injections.scm");
+// pub const LOCALS_QUERY: &str = include_str!("../../queries/locals.scm");
+// pub const TAGS_QUERY: &str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {
@@ -46,7 +46,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
-            .expect("Error loading proto language");
+            .set_language(&super::LANGUAGE.into())
+            .expect("Error loading Proto parser");
     }
 }

--- a/bindings/swift/TreeSitterProtoTests/TreeSitterProtoTests.swift
+++ b/bindings/swift/TreeSitterProtoTests/TreeSitterProtoTests.swift
@@ -1,0 +1,12 @@
+import XCTest
+import SwiftTreeSitter
+import TreeSitterProto
+
+final class TreeSitterProtoTests: XCTestCase {
+    func testCanLoadGrammar() throws {
+        let parser = Parser()
+        let language = Language(language: tree_sitter_proto())
+        XCTAssertNoThrow(try parser.setLanguage(language),
+                         "Error loading Proto grammar")
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/tree-sitter/tree-sitter-proto
+
+go 1.23
+
+require github.com/tree-sitter/go-tree-sitter v0.23

--- a/package.json
+++ b/package.json
@@ -6,8 +6,9 @@
   "types": "bindings/node",
   "scripts": {
     "install": "node-gyp-build",
-    "prestart": "tree-sitter build --wasm",
-    "start": "tree-sitter playground",
+    "build": "npx tree-sitter-cli generate --no-bindings",
+    "prestart": "npx tree-sitter-cli build --wasm",
+    "start": "npx tree-sitter-cli playground",
     "test": "node --test bindings/node/*_test.js"
   },
   "keywords": [
@@ -29,7 +30,7 @@
     "node-gyp-build": "^4.8.0"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.23.0"
+    "tree-sitter": "^0.21.0"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,14 @@
 {
   "name": "tree-sitter-proto",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A tree-sitter grammar for protocol buffers (proto3)",
   "main": "bindings/node",
   "types": "bindings/node",
   "scripts": {
-    "build": "tree-sitter generate && node-gyp build",
-    "test": "tree-sitter test",
-    "test-windows": "tree-sitter test",
     "install": "node-gyp-build",
-    "prebuildify": "prebuildify --napi --strip"
+    "prestart": "tree-sitter build --wasm",
+    "start": "tree-sitter playground",
+    "test": "node --test bindings/node/*_test.js"
   },
   "keywords": [
     "tree-sitter",
@@ -30,7 +29,7 @@
     "node-gyp-build": "^4.8.0"
   },
   "peerDependencies": {
-    "tree-sitter": "^0.21.0"
+    "tree-sitter": "^0.23.0"
   },
   "peerDependenciesMeta": {
     "tree_sitter": {
@@ -38,7 +37,7 @@
     }
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.19.1",
+    "tree-sitter-cli": "^0.23.0",
     "prebuildify": "^6.0.0"
   },
   "tree-sitter": [

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "types": "bindings/node",
   "scripts": {
     "install": "node-gyp-build",
-    "build": "npx tree-sitter-cli generate --no-bindings",
-    "prestart": "npx tree-sitter-cli build --wasm",
-    "start": "npx tree-sitter-cli playground",
+    "build": "tree-sitter generate --no-bindings",
+    "prestart": "tree-sitter build --wasm",
+    "start": "tree-sitter playground",
     "test": "node --test bindings/node/*_test.js"
   },
   "keywords": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "tree-sitter-proto"
 description = "Proto grammar for tree-sitter"
-version = "0.0.1"
+version = "0.1.0"
 keywords = ["incremental", "parsing", "tree-sitter", "proto"]
 classifiers = [
   "Intended Audience :: Developers",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
             sources=[
                 "bindings/python/tree_sitter_proto/binding.c",
                 "src/parser.c",
-                # NOTE: if your language uses an external scanner, add it here.
             ],
             extra_compile_args=[
                 "-std=c11",

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -47,6 +47,7 @@ struct TSLexer {
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);
+  void (*log)(const TSLexer *, const char *, ...);
 };
 
 typedef enum {


### PR DESCRIPTION
Tree-sitter released version 0.23 recently. This contains a breaking, but ultimately very good change to how parser bindings work (https://github.com/tree-sitter/tree-sitter/pull/3069). The TLDR of that change is that parsers do not depend on tree-sitter anymore, but instead on a shard (and supposedly very stable) tree-sitter-language crate. As a result, clients are free to chose their tree-sitter version as the parser ABI is supported. Library and parser versions are less tighly coupled, and it should no longer be necessary to move all the parsers to the next tree-sitter version in lock-step to be able to upgrade the library.

Most of the changes in this PR are from running tree-sitter generate. I'll add comments on other changes I did to explain why I thought they are necessary, or where I'm not sure I did it correctly.